### PR TITLE
fix: change the constant for default format to 'full'

### DIFF
--- a/src/Util/Constants.php
+++ b/src/Util/Constants.php
@@ -8,7 +8,7 @@ namespace Lightszentip\LaravelReleaseChangelogGenerator\Util;
  */
 class Constants
 {
-    public const DEFAULT_FORMAT = 'all';
+    public const DEFAULT_FORMAT = 'full';
 
     public const APP_VERISON_HANDLING = 'releasechangelog.versionhandling';
 


### PR DESCRIPTION
The Format 'all' was not in the default config format set