### PR TITLE
Ability to generate CHANGELOG.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ php artisan changelog:release --releasename="My First Release" --type=patch
 
 This update the version.yml to the next patch vesion and add in the changelog.json a new release with all current changelog items.
 
+### Update CHANGELOG.md file:
+
+This will update the CHANGELOG.md file in the root with your changes.
+
+```shell
+php artisan changelog:generate-md
+```
+
 ### Get version in the application 
 
 #### Blade

--- a/resources/views/changelog-md.blade.php
+++ b/resources/views/changelog-md.blade.php
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 @foreach ($changelog as $release => $changelogItems)
-## [{{ ucfirst($release) }}]@if ($changelogItems->date) - {{ \Carbon\Carbon::parse($changelogItems->date)->format('Y-m-d') }} @endif
+## [{{ ucfirst($release) }}]@if ($changelogItems['date']) - {{ \Carbon\Carbon::parse($changelogItems['date'])->format('Y-m-d') }} @endif
 
 @foreach ($changelogItems as $changeType => $items)
 @if (is_array($items))
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### {{ ucfirst($changeType) }}
 
 @foreach ($items as $item)
-- {{ $item->message }}
+- {{ $item['message'] }}
 @endforeach
 @endif
 @endforeach

--- a/resources/views/changelog-md.blade.php
+++ b/resources/views/changelog-md.blade.php
@@ -5,17 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 @foreach ($changelog as $release => $changelogItems)
+## [{{ ucfirst($release) }}]@if ($changelogItems->date) - {{ \Carbon\Carbon::parse($changelogItems->date)->format('Y-m-d') }} @endif
 
-    ## [{{ ucfirst($release) }}]@if ($changelogItems->date) - {{ \Carbon\Carbon::parse($changelogItems->date)->format('Y-m-d') }} @endif
+@foreach ($changelogItems as $changeType => $items)
+@if (is_array($items))
 
-    @foreach ($changelogItems as $changeType => $items)
-        @if (is_array($items))
+### {{ ucfirst($changeType) }}
 
-            ### {{ ucfirst($changeType) }}
-
-            @foreach ($items as $item)
-                - {{ $item->message }}
-            @endforeach
-        @endif
-    @endforeach
+@foreach ($items as $item)
+- {{ $item->message }}
+@endforeach
+@endif
+@endforeach
 @endforeach

--- a/resources/views/changelog-md.blade.php
+++ b/resources/views/changelog-md.blade.php
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+@foreach ($changelog as $release => $changelogItems)
+
+    ## [{{ ucfirst($release) }}]@if ($changelogItems->date) - {{ \Carbon\Carbon::parse($changelogItems->date)->format('Y-m-d') }} @endif
+
+    @foreach ($changelogItems as $changeType => $items)
+        @if (is_array($items))
+
+            ### {{ ucfirst($changeType) }}
+
+            @foreach ($items as $item)
+                - {{ $item->message }}
+            @endforeach
+        @endif
+    @endforeach
+@endforeach

--- a/resources/views/changelog-md.blade.php
+++ b/resources/views/changelog-md.blade.php
@@ -17,4 +17,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 @endforeach
 @endif
 @endforeach
+
 @endforeach

--- a/src/Commands/GenerateChangelogMdCommand.php
+++ b/src/Commands/GenerateChangelogMdCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lightszentip\LaravelReleaseChangelogGenerator\Commands;
+
+use Illuminate\Console\Command;
+use Lightszentip\LaravelReleaseChangelogGenerator\Util\Constants;
+use Lightszentip\LaravelReleaseChangelogGenerator\Util\FileHandler;
+use Illuminate\Support\Facades\File;
+
+class GenerateChangelogMdCommand extends Command
+{
+    protected $signature = 'changelog:generate-md';
+
+    protected $description = 'Update CHANGELOG.md file';
+
+    public function handle()
+    {
+        $changelogData = json_decode(
+            File::get(FileHandler::pathChangelog(true))
+        );
+
+        File::put(FileHandler::pathChangelogMd(), view('changelog-md', [
+            'changelog' => $changelogData
+        ]));
+    }
+}

--- a/src/Commands/GenerateChangelogMdCommand.php
+++ b/src/Commands/GenerateChangelogMdCommand.php
@@ -16,9 +16,12 @@ class GenerateChangelogMdCommand extends Command
     public function handle()
     {
         $changelogData = json_decode(
-            File::get(FileHandler::pathChangelog(true))
+            File::get(FileHandler::pathChangelog(true)),
+            true
         );
 
+        krsort($changelogData);
+        
         File::put(FileHandler::pathChangelogMd(), view('changelog-md', [
             'changelog' => $changelogData
         ]));

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,6 +11,7 @@ use Lightszentip\LaravelReleaseChangelogGenerator\Commands\ReleaseChangelog;
 use Lightszentip\LaravelReleaseChangelogGenerator\Commands\SetReleaseChangelog;
 use Lightszentip\LaravelReleaseChangelogGenerator\Commands\UpdateVersion;
 use Lightszentip\LaravelReleaseChangelogGenerator\Commands\ShowVersion;
+use Lightszentip\LaravelReleaseChangelogGenerator\Commands\GenerateChangelogMdCommand;
 use Lightszentip\LaravelReleaseChangelogGenerator\Logic\Version;
 use Lightszentip\LaravelReleaseChangelogGenerator\Logic\VersionHandling;
 use Lightszentip\LaravelReleaseChangelogGenerator\Util\Constants;
@@ -19,9 +20,7 @@ class ServiceProvider extends IlluminateServiceProvider
 {
     public function register()
     {
-
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'releasechangelog');
-
 
         $this->app->singleton(Constants::APP_VERISON_HANDLING, function () {
             return new VersionHandling();
@@ -40,18 +39,18 @@ class ServiceProvider extends IlluminateServiceProvider
                 AddChangelog::class,
                 UpdateVersion::class,
                 ShowVersion::class,
-                SetReleaseChangelog::class
+                SetReleaseChangelog::class,
+                GenerateChangelogMdCommand::class,
             ]);
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('releasechangelog.php'),
             ], 'config');
 
             $this->publishes([
-
                 // Views
                 __DIR__.'/../resources/.version/version.yml' => resource_path('.version/version.yml'),
                 __DIR__.'/../resources/.changes/changelog.json' => resource_path('.changes/changelog.json'),
-
+                __DIR__.'/../resources/views/changelog-md.blade.php' => resource_path('views/changelog-md.blade.php'),
             ], 'resources');
 
         }

--- a/src/Util/FileHandler.php
+++ b/src/Util/FileHandler.php
@@ -35,4 +35,9 @@ class FileHandler
     {
         return resource_path().DIRECTORY_SEPARATOR.'.version'.DIRECTORY_SEPARATOR.'version.yml';
     }
+
+    public static function pathChangelogMd()
+    {
+        return base_path('CHANGELOG.md');
+    }
 }


### PR DESCRIPTION
This will add a new command to generate a `CHANGELOG.md` file in the root of your Laravel project.